### PR TITLE
Make it work with newer React-Native versions.

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -16,5 +16,5 @@ android {
 }
 
 dependencies {
-    compile 'com.facebook.react:react-native:0.37.+'
+    compile 'com.facebook.react:react-native:+'
 }


### PR DESCRIPTION
I think we shouldn't set a hard coded constrain here. Instead we should document it in the readme with which version it is tested and working?