### PR TITLE
Fixes breaking change in RN 0.47

### DIFF
--- a/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsPackage.java
+++ b/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsPackage.java
@@ -13,13 +13,6 @@ import java.util.ArrayList;
 
 public class ExtraDimensionsPackage implements ReactPackage {
 
-
-    @Override
-    public List<Class<? extends JavaScriptModule>> createJSModules() {
-        return Collections.emptyList();
-    }
-
-
     @Override
     public List<ViewManager> createViewManagers(ReactApplicationContext reactContext) {
         return Arrays.asList();


### PR DESCRIPTION
As of RN 0.47 modules no longer need to override createJsModules

Fixes:
`ExtraDimensionsPackage.java:17: error: method does not override or implement a method from a supertype
`