### PR TITLE
Add title and extension to LICENSE file

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,3 +1,5 @@
+## ISC License
+
 Copyright (c) 2015, Jack Hsu
 
 Permission to use, copy, modify, and/or distribute this software for any purpose with or without fee is hereby granted, provided that the above copyright notice and this permission notice appear in all copies.


### PR DESCRIPTION
The title is not legally mandated, but it's recommended in the license template text (see http://choosealicense.com/licenses/isc/ and https://opensource.org/licenses/isc-license).

The extension is needed to trigger soft text-wrapping on the GitHub interface, which otherwise displays long lines overflowing the container.

*This PR is part of a project to improve the consistency and visibility of the ISC license. See https://github.com/github/choosealicense.com/issues/377 for more details.*