### PR TITLE
Add support for RN 0.55

### DIFF
--- a/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsPackage.java
+++ b/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsPackage.java
@@ -17,7 +17,6 @@ public class ExtraDimensionsPackage implements ReactPackage {
         return Arrays.asList();
     }
 
-    @Override 
     public List<Class<? extends JavaScriptModule>> createJSModules() { 
         return Collections.emptyList(); 
     }


### PR DESCRIPTION
Fixes the error `error: method does not override or implement a method from a supertype`.