### PR TITLE
fix: Build with RN 0.58.4 and android SDK 28 fail

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -5,12 +5,12 @@ def safeExtGet(prop, fallback) {
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 27
-    buildToolsVersion "27.0.3"
+    compileSdkVersion rootProject.ext.compileSdkVersion
+    buildToolsVersion rootProject.ext.buildToolsVersion
 
     defaultConfig {
-        minSdkVersion 16
-        targetSdkVersion 26
+        minSdkVersion rootProject.ext.minSdkVersion
+        targetSdkVersion rootProject.ext.targetSdkVersion
         versionCode 1
         versionName "1.0"
         ndk {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-extra-dimensions-android",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Access additional display metrics on Android devices: status bar height, soft menu bar height, real screen size.",
   "main": "index.js",
   "repository": {


### PR DESCRIPTION
Fixed error while building a production bug in react-native 0.58.4 app.