### PR TITLE
Switch to module syntax, support React Native for Web

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -7,6 +7,12 @@ declare type Dimensions =
 
 declare interface ExtraDimensions {
   get: (dim: Dimensions) => number;
+  getRealWindowHeight: () => number;
+  getRealWindowWidth: () => number;
+  getStatusBarHeight: () => number;
+  getSoftMenuBarHeight: () => number;
+  getSmartBarHeight: () => number;
+  isSoftMenuBarEnabled: () => number;
 }
 
 declare module "react-native-extra-dimensions-android" {

--- a/index.js
+++ b/index.js
@@ -1,47 +1,58 @@
-const React = require('react');
-var { NativeModules, Platform } = require('react-native');
+import { NativeModules, Platform } from 'react-native';
 
-if (Platform.OS === 'android') {
-  module.exports = {
-    get(dim) {
-      try {
-        if(!NativeModules.ExtraDimensions) {
-          throw "ExtraDimensions not defined. Try rebuilding your project. e.g. react-native run-android";
-        }
-        const result = NativeModules.ExtraDimensions[dim];
+export function get(dim) {
+  if (Platform.OS !== 'android') {
 
-        if(typeof result !== 'number') {
-            return result;
-        }
-        return result;
-      } catch (e) {
-        console.error(e);
+    console.warn('react-native-extra-dimensions-android is only available on Android. Trying to access', dim);
+    return 0;
+  } else { // android
+    try {
+      if (!NativeModules.ExtraDimensions) {
+        throw "ExtraDimensions not defined. Try rebuilding your project. e.g. react-native run-android";
       }
-    },
-    getRealWindowHeight() {
-      return this.get('REAL_WINDOW_HEIGHT');
-    },
-    getRealWindowWidth() {
-      return this.get('REAL_WINDOW_WIDTH');
-    },
-    getStatusBarHeight() {
-      return this.get('STATUS_BAR_HEIGHT');
-    },
-    getSoftMenuBarHeight() {
-      return this.get('SOFT_MENU_BAR_HEIGHT');
-    },
-    getSmartBarHeight() {
-      return this.get('SMART_BAR_HEIGHT');
-    },
-    isSoftMenuBarEnabled() {
-      return this.get('SOFT_MENU_BAR_ENABLED');
+      const result = NativeModules.ExtraDimensions[dim];
+
+      if (typeof result !== 'number') {
+        return result;
+      }
+      return result;
+    } catch (e) {
+      console.error(e);
     }
-  };
-} else {
-  module.exports = {
-    get(dim) {
-      console.warn('react-native-extra-dimensions-android is only available on Android');
-      return 0;
-    }
-  };
+  }
+}
+
+export function getRealWindowHeight() {
+  return get('REAL_WINDOW_HEIGHT');
+}
+
+export function getRealWindowWidth() {
+  return get('REAL_WINDOW_WIDTH');
+}
+
+export function getStatusBarHeight() {
+  return get('STATUS_BAR_HEIGHT');
+}
+
+export function getSoftMenuBarHeight() {
+  return get('SOFT_MENU_BAR_HEIGHT');
+}
+
+export function getSmartBarHeight() {
+  return get('SMART_BAR_HEIGHT');
+}
+
+export function isSoftMenuBarEnabled() {
+  return get('SOFT_MENU_BAR_ENABLED');
+}
+
+// stay compatible with pre-es6 exports
+export default {
+  get,
+  getRealWindowHeight,
+  getRealWindowWidth,
+  getStatusBarHeight,
+  getSoftMenuBarHeight,
+  getSmartBarHeight,
+  isSoftMenuBarEnabled
 }


### PR DESCRIPTION
This PR switches to the Ecmascript Module Syntax.
Switching from commonJs allows tree shaking to work which is especially relevant on the web.

Enables support for [React Native for Web](https://github.com/necolas/react-native-web).

I also unified the interface of the package the be the same for all platforms.

