### PR TITLE
Fixed getSoftMenuBarHeight() not returning the right value on notched devices

### DIFF
--- a/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsModule.java
+++ b/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsModule.java
@@ -103,16 +103,12 @@ public class ExtraDimensionsModule extends ReactContextBaseJavaModule implements
         if(hasPermanentMenuKey()) {
             return 0;
         }
-        final float realHeight = getRealHeight(metrics);
         final Context ctx = getReactApplicationContext();
-        final DisplayMetrics usableMetrics = ctx.getResources().getDisplayMetrics();
-
-        // Passing getMetrics will update the value of the Object DisplayMetrics metrics
-        ((WindowManager) mReactContext.getSystemService(Context.WINDOW_SERVICE))
-                .getDefaultDisplay().getMetrics(metrics);
-        final int usableHeight = usableMetrics.heightPixels;
-
-        return Math.max(0, realHeight - usableHeight / metrics.density);
+        final int heightResId = ctx.getResources().getIdentifier("navigation_bar_height", "dimen", "android");
+        return
+          heightResId > 0
+            ? ctx.getResources().getDimensionPixelSize(heightResId) / metrics.density
+            : 0;
     }
 
     private float getRealHeight(DisplayMetrics metrics) {


### PR DESCRIPTION
This PR fixes the issue found in https://github.com/Sunhat/react-native-extra-dimensions-android/issues/43

Old behavior:

![image](https://user-images.githubusercontent.com/792891/55360250-a6aaaf00-5488-11e9-9618-7e31dba1e575.png)


New behavior:

![image](https://user-images.githubusercontent.com/792891/55360259-ad392680-5488-11e9-9e44-7d83332469ef.png)


I used [this gist](https://gist.github.com/hamakn/8939eb68a920a6d7a498) as inspiration since I don't know much about Android. 

Is there any reason you weren't doing calculations this way before?