### PR TITLE
Fixed build issue and hasPermanentMenuKey() returning the wrong value

### DIFF
--- a/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsModule.java
+++ b/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsModule.java
@@ -87,7 +87,7 @@ public class ExtraDimensionsModule extends ReactContextBaseJavaModule implements
     private boolean hasPermanentMenuKey() {
         final Context ctx = getReactApplicationContext();
         int id = ctx.getResources().getIdentifier("config_showNavigationBar", "bool", "android");
-        return id > 0 && !ctx.getResources().getBoolean(id);
+        return !(id > 0 && ctx.getResources().getBoolean(id));
     }
 
     private float getStatusBarHeight(DisplayMetrics metrics) {

--- a/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsModule.java
+++ b/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsModule.java
@@ -85,9 +85,10 @@ public class ExtraDimensionsModule extends ReactContextBaseJavaModule implements
     }
 
     private boolean hasPermanentMenuKey() {
-        resources = ctx.getResources();
-        int id = resources.getIdentifier("config_showNavigationBar", "bool", "android");
-        return id > 0 && resources.getBoolean(id);
+        final Context ctx = getReactApplicationContext();
+        final Resources res = ctx.getResources();
+        int id = res.getIdentifier("config_showNavigationBar", "bool", "android");
+        return id > 0 && res.getBoolean(id);
     }
 
     private float getStatusBarHeight(DisplayMetrics metrics) {

--- a/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsModule.java
+++ b/android/src/main/java/ca/jaysoo/extradimensions/ExtraDimensionsModule.java
@@ -86,9 +86,8 @@ public class ExtraDimensionsModule extends ReactContextBaseJavaModule implements
 
     private boolean hasPermanentMenuKey() {
         final Context ctx = getReactApplicationContext();
-        final Resources res = ctx.getResources();
-        int id = res.getIdentifier("config_showNavigationBar", "bool", "android");
-        return id > 0 && res.getBoolean(id);
+        int id = ctx.getResources().getIdentifier("config_showNavigationBar", "bool", "android");
+        return id > 0 && !ctx.getResources().getBoolean(id);
     }
 
     private float getStatusBarHeight(DisplayMetrics metrics) {


### PR DESCRIPTION
There was a build issue in the latest version because `resources` wasn't being defined:

![image](https://user-images.githubusercontent.com/792891/55438303-13d84600-5556-11e9-9e0b-3c3bd8c13639.png)

Also fixed a new issue that also appeared with 5b3e14e057afaac898057feaa4109f2963c43970 where `hasPermanentMenuKey()` started returning the exact opposite value (it returned if the phone had a navigation bar instead of a permanent menu key).