### PR TITLE
migrate to react-native.config

### DIFF
--- a/package.json
+++ b/package.json
@@ -18,11 +18,6 @@
     "react",
     "android"
   ],
-  "rnpm": {
-    "android": {
-      "packageInstance": "new ExtraDimensionsPackage()"
-    }
-  },
   "author": "Jack Hsu <jack.hsu@gmail.com> (http://jaysoo.ca/)",
   "license": "ISC"
 }

--- a/react-native.config.js
+++ b/react-native.config.js
@@ -1,0 +1,9 @@
+module.exports = {
+  dependency: {
+    platforms: {
+      android: {
+        packageInstance: "new ExtraDimensionsPackage()"
+      }
+    }
+  }
+};


### PR DESCRIPTION
React Native 0.60 warns about deprecated "rnpm" config:

```bash
warn The following packages use deprecated "rnpm" config that will stop working from next release:
- react-native-extra-dimensions-android: https://npmjs.com/package/react-native-extra-dimensions-android
Please notify their maintainers about it. You can find more details at https://github.com/react-native-community/cli/blob/master/docs/configuration.md#migration-guide.
```

This PR migrates from `rnpm` to use `react-native.config.js`.